### PR TITLE
feat: 업무 생성/수정 시 그룹을 담당자/참조자로 설정 지원

### DIFF
--- a/src/main/kotlin/com/bifos/dooray/mcp/tools/CreateProjectPostTool.kt
+++ b/src/main/kotlin/com/bifos/dooray/mcp/tools/CreateProjectPostTool.kt
@@ -34,12 +34,22 @@ fun createProjectPostTool(): Tool {
                         putJsonObject("to_member_ids") {
                             put("type", "array")
                             putJsonObject("items") { put("type", "string") }
-                            put("description", "담당자 멤버 ID 목록 (필수)")
+                            put("description", "담당자 멤버 ID 목록 (to_member_ids 또는 to_group_ids 중 하나 이상 필수)")
+                        }
+                        putJsonObject("to_group_ids") {
+                            put("type", "array")
+                            putJsonObject("items") { put("type", "string") }
+                            put("description", "담당자 그룹 ID 목록 (projectMemberGroupId). dooray_project_list_members에서 그룹 ID 확인 가능 (선택사항)")
                         }
                         putJsonObject("cc_member_ids") {
                             put("type", "array")
                             putJsonObject("items") { put("type", "string") }
                             put("description", "참조자 멤버 ID 목록 (선택사항)")
+                        }
+                        putJsonObject("cc_group_ids") {
+                            put("type", "array")
+                            putJsonObject("items") { put("type", "string") }
+                            put("description", "참조자 그룹 ID 목록 (projectMemberGroupId). dooray_project_list_members에서 그룹 ID 확인 가능 (선택사항)")
                         }
                         putJsonObject("parent_post_id") {
                             put("type", "string")
@@ -83,24 +93,28 @@ fun createProjectPostHandler(
             val subject = request.requireParam("subject", "MISSING_SUBJECT", "subject 파라미터가 필요합니다. 업무 제목을 입력하세요.")
             val body = request.requireParam("body", "MISSING_BODY", "body 파라미터가 필요합니다. 업무 내용을 입력하세요.")
 
-            val toMemberIds = request.arguments?.get("to_member_ids")?.let { JsonUtils.parseStringArray(it.toString()) }
-            if (toMemberIds.isNullOrEmpty()) {
+            val toMemberIds = request.arguments?.get("to_member_ids")?.let { JsonUtils.parseStringArray(it.toString()) } ?: emptyList()
+            val toGroupIds = request.arguments?.get("to_group_ids")?.let { JsonUtils.parseStringArray(it.toString()) } ?: emptyList()
+            if (toMemberIds.isEmpty() && toGroupIds.isEmpty()) {
                 throw com.bifos.dooray.mcp.exception.ToolException(
                     type = com.bifos.dooray.mcp.exception.ToolException.PARAMETER_MISSING,
-                    message = "to_member_ids 파라미터가 필요합니다. 담당자 멤버 ID 목록을 입력하세요.",
-                    code = "MISSING_TO_MEMBER_IDS"
+                    message = "to_member_ids 또는 to_group_ids 중 하나 이상 필요합니다. 담당자 멤버 ID 또는 그룹 ID 목록을 입력하세요.",
+                    code = "MISSING_TO_USERS"
                 )
             }
 
             val ccMemberIds = request.arguments?.get("cc_member_ids")?.let { JsonUtils.parseStringArray(it.toString()) } ?: emptyList()
+            val ccGroupIds = request.arguments?.get("cc_group_ids")?.let { JsonUtils.parseStringArray(it.toString()) } ?: emptyList()
             val parentPostId = request.optionalParam("parent_post_id")
             val dueDate = request.optionalParam("due_date")
             val milestoneId = request.optionalParam("milestone_id")
             val tagIds = request.arguments?.get("tag_ids")?.let { JsonUtils.parseStringArray(it.toString()) } ?: emptyList()
             val priority = request.arguments?.get("priority")?.jsonPrimitive?.content ?: "none"
 
-            val toUsers = toMemberIds.map { CreatePostUser(type = "member", member = Member(organizationMemberId = it)) }
-            val ccUsers = ccMemberIds.map { CreatePostUser(type = "member", member = Member(organizationMemberId = it)) }
+            val toUsers = toMemberIds.map { CreatePostUser(type = "member", member = Member(organizationMemberId = it)) } +
+                    toGroupIds.map { CreatePostUser(type = "group", group = Group(projectMemberGroupId = it)) }
+            val ccUsers = ccMemberIds.map { CreatePostUser(type = "member", member = Member(organizationMemberId = it)) } +
+                    ccGroupIds.map { CreatePostUser(type = "group", group = Group(projectMemberGroupId = it)) }
 
             val createRequest = CreatePostRequest(
                 parentPostId = parentPostId,

--- a/src/main/kotlin/com/bifos/dooray/mcp/tools/UpdateProjectPostTool.kt
+++ b/src/main/kotlin/com/bifos/dooray/mcp/tools/UpdateProjectPostTool.kt
@@ -32,12 +32,22 @@ fun updateProjectPostTool(): Tool {
                         putJsonObject("to_member_ids") {
                             put("type", "array")
                             putJsonObject("items") { put("type", "string") }
-                            put("description", "담당자 멤버 ID 목록 (선택사항)")
+                            put("description", "담당자 멤버 ID 목록 (선택사항, 지정 시 기존 담당자 전체 교체)")
+                        }
+                        putJsonObject("to_group_ids") {
+                            put("type", "array")
+                            putJsonObject("items") { put("type", "string") }
+                            put("description", "담당자 그룹 ID 목록 (projectMemberGroupId, 선택사항, to_member_ids와 함께 사용 가능)")
                         }
                         putJsonObject("cc_member_ids") {
                             put("type", "array")
                             putJsonObject("items") { put("type", "string") }
-                            put("description", "참조자 멤버 ID 목록 (선택사항)")
+                            put("description", "참조자 멤버 ID 목록 (선택사항, 지정 시 기존 참조자 전체 교체)")
+                        }
+                        putJsonObject("cc_group_ids") {
+                            put("type", "array")
+                            putJsonObject("items") { put("type", "string") }
+                            put("description", "참조자 그룹 ID 목록 (projectMemberGroupId, 선택사항, cc_member_ids와 함께 사용 가능)")
                         }
                         putJsonObject("priority") {
                             put("type", "string")
@@ -97,26 +107,41 @@ fun updateProjectPostHandler(
             val dueDate = request.optionalParam("due_date") ?: existingPost.dueDate
 
             val toMemberIds = request.arguments?.get("to_member_ids")?.jsonArray?.mapNotNull { it.jsonPrimitive.content }
+            val toGroupIds = request.arguments?.get("to_group_ids")?.jsonArray?.mapNotNull { it.jsonPrimitive.content }
             val ccMemberIds = request.arguments?.get("cc_member_ids")?.jsonArray?.mapNotNull { it.jsonPrimitive.content }
+            val ccGroupIds = request.arguments?.get("cc_group_ids")?.jsonArray?.mapNotNull { it.jsonPrimitive.content }
             val tagIds = request.arguments?.get("tag_ids")?.jsonArray?.mapNotNull { it.jsonPrimitive.content }
                 ?: existingPost.tags.map { it.id }
 
-            val users = CreatePostUsers(
-                to = if (toMemberIds != null) {
-                    toMemberIds.map { CreatePostUser(type = "member", member = Member(it)) }
-                } else {
-                    existingPost.users.to.mapNotNull { postUser ->
-                        postUser.member?.let { CreatePostUser(type = "member", member = Member(it.organizationMemberId)) }
-                    }
-                },
-                cc = if (ccMemberIds != null) {
-                    ccMemberIds.map { CreatePostUser(type = "member", member = Member(it)) }
-                } else {
-                    existingPost.users.cc.mapNotNull { postUser ->
-                        postUser.member?.let { CreatePostUser(type = "member", member = Member(it.organizationMemberId)) }
+            // to/cc 중 어느 하나라도 지정되면 해당 to/cc 전체를 교체 (멤버 + 그룹 조합)
+            // 미지정 시 기존 업무의 멤버와 그룹을 모두 유지
+            val toUsers = if (toMemberIds != null || toGroupIds != null) {
+                (toMemberIds ?: emptyList()).map { CreatePostUser(type = "member", member = Member(it)) } +
+                        (toGroupIds ?: emptyList()).map { CreatePostUser(type = "group", group = Group(projectMemberGroupId = it)) }
+            } else {
+                existingPost.users.to.mapNotNull { postUser ->
+                    when (postUser.type) {
+                        "member" -> postUser.member?.let { CreatePostUser(type = "member", member = Member(it.organizationMemberId)) }
+                        "group" -> postUser.group?.let { CreatePostUser(type = "group", group = Group(projectMemberGroupId = it.projectMemberGroupId)) }
+                        else -> null
                     }
                 }
-            )
+            }
+
+            val ccUsers = if (ccMemberIds != null || ccGroupIds != null) {
+                (ccMemberIds ?: emptyList()).map { CreatePostUser(type = "member", member = Member(it)) } +
+                        (ccGroupIds ?: emptyList()).map { CreatePostUser(type = "group", group = Group(projectMemberGroupId = it)) }
+            } else {
+                existingPost.users.cc.mapNotNull { postUser ->
+                    when (postUser.type) {
+                        "member" -> postUser.member?.let { CreatePostUser(type = "member", member = Member(it.organizationMemberId)) }
+                        "group" -> postUser.group?.let { CreatePostUser(type = "group", group = Group(projectMemberGroupId = it.projectMemberGroupId)) }
+                        else -> null
+                    }
+                }
+            }
+
+            val users = CreatePostUsers(to = toUsers, cc = ccUsers)
 
             val updateRequest = UpdatePostRequest(
                 users = users,

--- a/src/main/kotlin/com/bifos/dooray/mcp/types/ProjectPostResponse.kt
+++ b/src/main/kotlin/com/bifos/dooray/mcp/types/ProjectPostResponse.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.Serializable
 @Serializable data class EmailUser(val emailAddress: String, val name: String)
 
 /** 그룹 정보 */
-@Serializable data class Group(val projectMemberGroupId: String, val members: List<Member>)
+@Serializable data class Group(val projectMemberGroupId: String, val members: List<Member> = emptyList())
 
 /** 업무 관련 사용자 - 기본 타입 */
 @Serializable
@@ -119,9 +119,10 @@ data class CreatePostUsers(
 /** 업무 생성용 사용자 */
 @Serializable
 data class CreatePostUser(
-        val type: String, // "member", "emailUser"
+        val type: String, // "member", "emailUser", "group"
         val member: Member? = null,
-        val emailUser: EmailUser? = null
+        val emailUser: EmailUser? = null,
+        val group: Group? = null
 )
 
 /** 업무 수정 요청 */

--- a/src/test/kotlin/com/bifos/dooray/mcp/tools/McpToolsUnitTest.kt
+++ b/src/test/kotlin/com/bifos/dooray/mcp/tools/McpToolsUnitTest.kt
@@ -370,7 +370,7 @@ class McpToolsUnitTest {
     }
 
     @Test
-    @DisplayName("업무 생성 도구 - to_member_ids 누락 에러")
+    @DisplayName("업무 생성 도구 - to_member_ids, to_group_ids 모두 누락 에러")
     fun testCreateProjectPostHandlerMissingToMemberIds() = runTest {
         // given
         val mockDoorayClient = mockk<DoorayClient>()
@@ -381,7 +381,7 @@ class McpToolsUnitTest {
                     put("project_id", "project1")
                     put("subject", "새 업무")
                     put("body", "새 업무 내용")
-                    // to_member_ids 누락
+                    // to_member_ids, to_group_ids 모두 누락
                 }
 
         // when
@@ -394,7 +394,7 @@ class McpToolsUnitTest {
         val content = result.content.first() as TextContent
         val responseText = content.text
         assertContains(responseText, "\"isError\": true")
-        assertContains(responseText, "MISSING_TO_MEMBER_IDS")
+        assertContains(responseText, "MISSING_TO_USERS")
     }
 
     @Test


### PR DESCRIPTION
## 배경

두레이 API는 업무 담당자(to)/참조자(cc)에 멤버뿐만 아니라 그룹(projectMemberGroup)도 지원합니다.
기존 MCP 도구는 멤버 ID만 받을 수 있어 그룹을 참조자로 설정하는 것이 불가능했습니다.

## 변경 내용

### 타입 변경 (`ProjectPostResponse.kt`)
- `Group.members`를 optional로 변경 — 요청 시 `projectMemberGroupId`만 필요
- `CreatePostUser`에 `group: Group? = null` 필드 추가 (`type = "group"` 지원)

### `dooray_project_create_post`
- `to_group_ids` 파라미터 추가 (담당자 그룹 ID 목록)
- `cc_group_ids` 파라미터 추가 (참조자 그룹 ID 목록)
- `to_member_ids`와 `to_group_ids` 중 하나 이상 필수 (기존: `to_member_ids` 단독 필수)

### `dooray_project_update_post`
- `to_group_ids`, `cc_group_ids` 파라미터 추가
- fallback 로직 개선: 파라미터 미지정 시 기존 업무의 멤버 **및 그룹** 모두 보존
  (기존: 멤버만 보존, 그룹은 소실되는 버그 수정)

## 사용 예시

```json
{
  "name": "dooray_project_create_post",
  "arguments": {
    "project_id": "my-project",
    "subject": "새 업무",
    "body": "내용",
    "to_member_ids": ["member_id_1"],
    "cc_group_ids": ["group_id_1", "group_id_2"]
  }
}
```

## 테스트

- [x] `CI=true ./gradlew clean build` — 38 tests passed
- [x] 단위 테스트 에러 코드 업데이트 (`MISSING_TO_MEMBER_IDS` → `MISSING_TO_USERS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)