### PR TITLE
fix: 멤버가 아닌 프로젝트의 숫자 ID도 통과시켜 Post 접근 허용

### DIFF
--- a/src/main/kotlin/com/bifos/dooray/mcp/service/ProjectResolver.kt
+++ b/src/main/kotlin/com/bifos/dooray/mcp/service/ProjectResolver.kt
@@ -61,6 +61,15 @@ class ProjectResolver(private val doorayClient: DoorayClient) {
             return resolved.id
         }
 
+        // Not found in the accessible-projects list. If the input is a numeric project ID,
+        // pass it through as-is: the user may have access to a post inside a project they are
+        // not a member of (so it never appears in getProjects), and the downstream Dooray API
+        // will enforce authorization. Only non-numeric codes/names that can't be resolved error.
+        if (input.isNotEmpty() && input.all { it.isDigit() }) {
+            log.debug("ProjectResolver: '{}' not in accessible projects; treating as raw project ID", input)
+            return input
+        }
+
         // Not found — throw with helpful message listing available codes
         val availableCodes = cacheByCode.keys.sorted().joinToString(", ")
         throw ToolException(

--- a/src/main/kotlin/com/bifos/dooray/mcp/service/ProjectResolver.kt
+++ b/src/main/kotlin/com/bifos/dooray/mcp/service/ProjectResolver.kt
@@ -22,8 +22,16 @@ class ProjectResolver(private val doorayClient: DoorayClient) {
     private val ttl: Duration = Duration.ofMinutes(
         Env.getLong(DOORAY_PROJECT_CACHE_TTL_MINUTES, default = 5L)
     )
+    private val rawProjectIdPattern = Regex("^[0-9]{15,}$")
 
     suspend fun resolveProjectId(input: String): String {
+        // Dooray ID는 15자리 이상의 ASCII 숫자다. 프로젝트 목록에 없는 ID도
+        // 특정 업무에는 접근할 수 있으므로 목록 조회 없이 원격 API에 권한 판정을 맡긴다.
+        if (rawProjectIdPattern.matches(input)) {
+            log.debug("ProjectResolver: treating '{}' as a raw project ID", input)
+            return input
+        }
+
         // If it looks like a numeric ID and is in cache, return it directly
         if (cacheById.containsKey(input)) {
             return input
@@ -59,15 +67,6 @@ class ProjectResolver(private val doorayClient: DoorayClient) {
         if (resolved != null) {
             log.debug("ProjectResolver: resolved code '{}' -> id '{}' (after refresh)", input, resolved.id)
             return resolved.id
-        }
-
-        // Not found in the accessible-projects list. If the input is a numeric project ID,
-        // pass it through as-is: the user may have access to a post inside a project they are
-        // not a member of (so it never appears in getProjects), and the downstream Dooray API
-        // will enforce authorization. Only non-numeric codes/names that can't be resolved error.
-        if (input.isNotEmpty() && input.all { it.isDigit() }) {
-            log.debug("ProjectResolver: '{}' not in accessible projects; treating as raw project ID", input)
-            return input
         }
 
         // Not found — throw with helpful message listing available codes

--- a/src/test/kotlin/com/bifos/dooray/mcp/service/ProjectResolverTest.kt
+++ b/src/test/kotlin/com/bifos/dooray/mcp/service/ProjectResolverTest.kt
@@ -122,6 +122,20 @@ class ProjectResolverTest {
     }
 
     @Test
+    @DisplayName("접근 권한 없는 프로젝트의 숫자 ID는 refresh 후에도 그대로 통과시킨다 (Post 접근 케이스)")
+    fun testUnknownNumericIdPassesThrough() = runTest {
+        // given: getProjects only returns projects the user is a member of (no "5555555555")
+        coEvery { mockDoorayClient.getProjects(page = 0, size = 100, any(), any(), any()) } returns
+            ProjectListResponse(header = successHeader, result = projects, totalCount = projects.size)
+
+        // when: a numeric ID outside the accessible-projects list (user has post access only)
+        val result = projectResolver.resolveProjectId("5555555555")
+
+        // then: passed through as-is; downstream API enforces authorization
+        assertEquals("5555555555", result)
+    }
+
+    @Test
     @DisplayName("두 번째 호출에서는 캐시를 사용한다 (API 1회만 호출)")
     fun testCacheIsUsedOnSecondCall() = runTest {
         // given

--- a/src/test/kotlin/com/bifos/dooray/mcp/service/ProjectResolverTest.kt
+++ b/src/test/kotlin/com/bifos/dooray/mcp/service/ProjectResolverTest.kt
@@ -122,17 +122,29 @@ class ProjectResolverTest {
     }
 
     @Test
-    @DisplayName("접근 권한 없는 프로젝트의 숫자 ID는 refresh 후에도 그대로 통과시킨다 (Post 접근 케이스)")
+    @DisplayName("접근 권한 없는 프로젝트의 숫자 ID는 목록 조회 없이 그대로 통과시킨다")
     fun testUnknownNumericIdPassesThrough() = runTest {
-        // given: getProjects only returns projects the user is a member of (no "5555555555")
+        // when: a Dooray ID outside the accessible-projects list is resolved repeatedly
+        val first = projectResolver.resolveProjectId("5555555555555555555")
+        val second = projectResolver.resolveProjectId("5555555555555555555")
+
+        // then: it passes through and the downstream API enforces authorization
+        assertEquals("5555555555555555555", first)
+        assertEquals(first, second)
+        coVerify(exactly = 0) { mockDoorayClient.getProjects(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    @DisplayName("ASCII가 아닌 숫자는 원시 프로젝트 ID로 처리하지 않는다")
+    fun testNonAsciiDigitsAreRejectedAsRawId() = runTest {
         coEvery { mockDoorayClient.getProjects(page = 0, size = 100, any(), any(), any()) } returns
             ProjectListResponse(header = successHeader, result = projects, totalCount = projects.size)
 
-        // when: a numeric ID outside the accessible-projects list (user has post access only)
-        val result = projectResolver.resolveProjectId("5555555555")
+        val ex = assertFailsWith<ToolException> {
+            projectResolver.resolveProjectId("１１１１１１１１１１１１１１１")
+        }
 
-        // then: passed through as-is; downstream API enforces authorization
-        assertEquals("5555555555", result)
+        assertEquals("PROJECT_NOT_FOUND", ex.code)
     }
 
     @Test


### PR DESCRIPTION
ProjectResolver가 getProjects 목록(멤버인 프로젝트)에만 의존해,
프로젝트 멤버가 아니지만 특정 Post에는 접근 가능한 경우 숫자 ID가
PROJECT_NOT_FOUND로 차단되던 문제 수정. 숫자 ID는 그대로 통과시키고
실제 권한 검증은 Dooray API에 위임한다.

#26 이슈 해결