### PR TITLE
feat: 위키 페이지 댓글 목록 조회 도구 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ NHN Dooray 서비스의 MCP(Model Context Protocol) 서버입니다.
 
 ## 주요 기능
 
-- **위키 관리**: 위키 조회, 생성, 수정
+- **위키 관리**: 위키 조회, 생성, 수정, 댓글 조회
 - **업무 관리**: 업무 조회, 생성, 수정, 상태 변경
 - **댓글 관리**: 업무 댓글 생성, 조회, 수정, 삭제
 - **프로젝트 코드 자동 매핑**: 프로젝트 이름(코드)을 입력하면 내부적으로 ID를 자동 resolve (캐시 기반)
@@ -71,9 +71,9 @@ docker run -e DOORAY_API_KEY="your_api_key" \
            bifos/dooray-mcp:latest
 ```
 
-## 사용 가능한 도구 (총 19개)
+## 사용 가능한 도구 (총 20개)
 
-### 위키 관련 도구 (5개)
+### 위키 관련 도구 (6개)
 
 #### 1. dooray_wiki_list_projects
 
@@ -95,13 +95,17 @@ docker run -e DOORAY_API_KEY="your_api_key" \
 
 기존 위키 페이지를 수정합니다.
 
+#### 6. dooray_wiki_get_page_comments
+
+특정 위키 페이지의 댓글 목록을 조회합니다. (최신순, 페이징 지원)
+
 ### 프로젝트 관련 도구 (2개)
 
-#### 6. dooray_project_list_projects
+#### 7. dooray_project_list_projects
 
 접근 가능한 프로젝트 목록을 조회합니다.
 
-#### 7. dooray_project_list_members
+#### 8. dooray_project_list_members
 
 프로젝트 멤버 목록을 조회합니다. 업무 담당자/참조자 지정 시 사용합니다.
 
@@ -109,53 +113,53 @@ docker run -e DOORAY_API_KEY="your_api_key" \
 
 > 💡 `project_id` 파라미터에 프로젝트 ID 또는 **프로젝트 코드(이름)**를 입력할 수 있습니다. 서버가 내부적으로 자동으로 ID를 resolve합니다.
 
-#### 8. dooray_project_list_posts
+#### 9. dooray_project_list_posts
 
 프로젝트의 업무 목록을 조회합니다.
 
-#### 9. dooray_project_get_post
+#### 10. dooray_project_get_post
 
 특정 업무의 상세 정보를 조회합니다.
 
-#### 10. dooray_project_create_post
+#### 11. dooray_project_create_post
 
 새로운 업무를 생성합니다.
 
-#### 11. dooray_project_update_post
+#### 12. dooray_project_update_post
 
 기존 업무를 수정합니다.
 
-#### 12. dooray_project_set_post_workflow
+#### 13. dooray_project_set_post_workflow
 
 업무의 상태(워크플로우)를 변경합니다.
 
-#### 13. dooray_project_set_post_done
+#### 14. dooray_project_set_post_done
 
 업무를 완료 상태로 변경합니다.
 
-#### 14. dooray_project_set_post_parent
+#### 15. dooray_project_set_post_parent
 
 업무의 상위 업무를 설정합니다.
 
-#### 15. dooray_project_list_workflows
+#### 16. dooray_project_list_workflows
 
 프로젝트의 워크플로우(업무 상태) 목록을 조회합니다.
 
 ### 업무 댓글 관련 도구 (4개)
 
-#### 16. dooray_project_create_post_comment
+#### 17. dooray_project_create_post_comment
 
 업무에 댓글을 생성합니다.
 
-#### 17. dooray_project_get_post_comments
+#### 18. dooray_project_get_post_comments
 
 업무의 댓글 목록을 조회합니다.
 
-#### 18. dooray_project_update_post_comment
+#### 19. dooray_project_update_post_comment
 
 업무 댓글을 수정합니다.
 
-#### 19. dooray_project_delete_post_comment
+#### 20. dooray_project_delete_post_comment
 
 업무 댓글을 삭제합니다.
 

--- a/src/main/kotlin/com/bifos/dooray/mcp/DoorayMcpServer.kt
+++ b/src/main/kotlin/com/bifos/dooray/mcp/DoorayMcpServer.kt
@@ -87,6 +87,7 @@ class DoorayMcpServer {
         addTool(getWikiPageTool(), getWikiPageHandler(doorayHttpClient))
         addTool(createWikiPageTool(), createWikiPageHandler(doorayHttpClient))
         addTool(updateWikiPageTool(), updateWikiPageHandler(doorayHttpClient))
+        addTool(getWikiPageCommentsTool(), getWikiPageCommentsHandler(doorayHttpClient))
         addTool(getProjectPostsTool(), getProjectPostsHandler(doorayHttpClient, projectResolver))
         addTool(getProjectPostTool(), getProjectPostHandler(doorayHttpClient, projectResolver))
         addTool(createProjectPostTool(), createProjectPostHandler(doorayHttpClient, projectResolver))

--- a/src/main/kotlin/com/bifos/dooray/mcp/client/DoorayClient.kt
+++ b/src/main/kotlin/com/bifos/dooray/mcp/client/DoorayClient.kt
@@ -29,6 +29,14 @@ interface DoorayClient {
         request: UpdateWikiPageRequest
     ): DoorayApiUnitResponse
 
+    /** 위키 페이지의 댓글 목록을 조회합니다. (최신순) */
+    suspend fun getWikiPageComments(
+        wikiId: String,
+        pageId: String,
+        page: Int? = null,
+        size: Int? = null
+    ): WikiCommentListResponse
+
     /** 프로젝트 내에 업무를 생성합니다. */
     suspend fun createPost(projectId: String, request: CreatePostRequest): CreatePostApiResponse
 

--- a/src/main/kotlin/com/bifos/dooray/mcp/client/DoorayHttpClient.kt
+++ b/src/main/kotlin/com/bifos/dooray/mcp/client/DoorayHttpClient.kt
@@ -218,6 +218,23 @@ class DoorayHttpClient(private val baseUrl: String, private val doorayApiKey: St
         ) { httpClient.put("/wiki/v1/wikis/$wikiId/pages/$pageId") { setBody(request) } }
     }
 
+    override suspend fun getWikiPageComments(
+            wikiId: String,
+            pageId: String,
+            page: Int?,
+            size: Int?
+    ): WikiCommentListResponse {
+        return executeApiCall(
+                operation = "GET /wiki/v1/wikis/$wikiId/pages/$pageId/comments",
+                successMessage = "✅ 위키 댓글 목록 조회 성공"
+        ) {
+            httpClient.get("/wiki/v1/wikis/$wikiId/pages/$pageId/comments") {
+                page?.let { parameter("page", it) }
+                size?.let { parameter("size", it) }
+            }
+        }
+    }
+
     override suspend fun createPost(
             projectId: String,
             request: CreatePostRequest

--- a/src/main/kotlin/com/bifos/dooray/mcp/tools/GetWikiPageCommentsTool.kt
+++ b/src/main/kotlin/com/bifos/dooray/mcp/tools/GetWikiPageCommentsTool.kt
@@ -1,0 +1,71 @@
+package com.bifos.dooray.mcp.tools
+
+import com.bifos.dooray.mcp.client.DoorayClient
+import com.bifos.dooray.mcp.types.WikiCommentsResponseData
+import io.modelcontextprotocol.kotlin.sdk.server.ClientConnection
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+
+fun getWikiPageCommentsTool(): Tool {
+    return Tool(
+        name = "dooray_wiki_get_page_comments",
+        description =
+            "특정 두레이 위키 페이지의 댓글 목록을 조회합니다. 최신순으로 응답하며(0 페이지의 첫 번째 원소가 가장 최신 댓글), 페이징을 지원합니다.",
+        inputSchema =
+            ToolSchema(
+                properties =
+                    buildJsonObject {
+                        putJsonObject("project_id") {
+                            put("type", "string")
+                            put("description", "위키 프로젝트 ID (dooray_wiki_list_projects로 조회 가능)")
+                        }
+                        putJsonObject("page_id") {
+                            put("type", "string")
+                            put("description", "위키 페이지 ID (dooray_wiki_list_pages로 조회 가능)")
+                        }
+                        paginationProperties(defaultSize = 20, maxSize = 100)
+                    },
+                required = listOf("project_id", "page_id")
+            ),
+        outputSchema = null,
+        annotations = null
+    )
+}
+
+fun getWikiPageCommentsHandler(doorayClient: DoorayClient): suspend (ClientConnection, CallToolRequest) -> CallToolResult {
+    return { _, request ->
+        toolHandler {
+            val projectId = request.requireParam(
+                "project_id", "MISSING_PROJECT_ID",
+                "project_id 파라미터가 필요합니다. dooray_wiki_list_projects를 사용해서 프로젝트 ID를 먼저 조회하세요."
+            )
+            val pageId = request.requireParam(
+                "page_id", "MISSING_PAGE_ID",
+                "page_id 파라미터가 필요합니다. dooray_wiki_list_pages를 사용해서 페이지 ID를 먼저 조회하세요."
+            )
+            val page = request.intParamOrNull("page")
+            val size = request.intParamOrNull("size")
+
+            val response = doorayClient.getWikiPageComments(projectId, pageId, page, size)
+
+            if (response.header.isSuccessful) {
+                successResult(
+                    data = WikiCommentsResponseData(
+                        comments = response.result,
+                        totalCount = response.totalCount,
+                        currentPage = page ?: 0,
+                        pageSize = size ?: 20
+                    ),
+                    message = "💬 위키 페이지 댓글 목록을 성공적으로 조회했습니다. (총 ${response.totalCount}개, 현재 페이지: ${response.result.size}개)"
+                )
+            } else {
+                apiErrorResult(response.header)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/bifos/dooray/mcp/types/ToolResponseTypes.kt
+++ b/src/main/kotlin/com/bifos/dooray/mcp/types/ToolResponseTypes.kt
@@ -20,6 +20,15 @@ data class PostCommentsResponseData(
         val pageSize: Int
 )
 
+/** 위키 댓글 목록 조회 응답 데이터 */
+@Serializable
+data class WikiCommentsResponseData(
+        val comments: List<WikiComment>,
+        val totalCount: Int,
+        val currentPage: Int,
+        val pageSize: Int
+)
+
 /** MCP Tool 에러 응답 */
 @Serializable
 data class ToolErrorResponse(

--- a/src/main/kotlin/com/bifos/dooray/mcp/types/WikiCommentResponse.kt
+++ b/src/main/kotlin/com/bifos/dooray/mcp/types/WikiCommentResponse.kt
@@ -1,0 +1,31 @@
+package com.bifos.dooray.mcp.types
+
+import kotlinx.serialization.Serializable
+
+/** 위키 댓글이 속한 페이지 정보 */
+@Serializable data class WikiCommentPage(val id: String)
+
+/** 위키 댓글 본문 (mimeType 고정: text/x-markdown) */
+@Serializable data class WikiCommentBody(val mimeType: String, val content: String? = null)
+
+/** 위키 댓글 정보 */
+@Serializable
+data class WikiComment(
+    val id: String,
+    val page: WikiCommentPage,
+    val createdAt: String? = null,
+    val modifiedAt: String? = null,
+    val creator: Creator,
+    val body: WikiCommentBody
+)
+
+/** 위키 댓글 목록 API 응답 */
+@Serializable
+data class WikiCommentListApiResponse(
+    val header: DoorayApiHeader,
+    val result: List<WikiComment>,
+    val totalCount: Int
+)
+
+/** 위키 댓글 목록 응답 타입 */
+typealias WikiCommentListResponse = WikiCommentListApiResponse

--- a/src/test/kotlin/com/bifos/dooray/mcp/McpServerIntegrationTest.kt
+++ b/src/test/kotlin/com/bifos/dooray/mcp/McpServerIntegrationTest.kt
@@ -42,6 +42,7 @@ class McpServerIntegrationTest {
             "dooray_wiki_get_page",
             "dooray_wiki_create_page",
             "dooray_wiki_update_page",
+            "dooray_wiki_get_page_comments",
             "dooray_project_list_projects",
             "dooray_project_list_members",
             "dooray_project_list_workflows",
@@ -60,7 +61,15 @@ class McpServerIntegrationTest {
 
         /** project_id를 required로 가져야 하는 도구 목록 */
         private val TOOLS_REQUIRING_PROJECT_ID = EXPECTED_TOOLS
-            .filter { it.startsWith("dooray_project_") && it != "dooray_project_list_projects" }
+            .filter {
+                (it.startsWith("dooray_project_") && it != "dooray_project_list_projects") ||
+                    it == "dooray_wiki_get_page_comments"
+            }
+
+        /** page_id를 required로 가져야 하는 도구 목록 */
+        private val TOOLS_REQUIRING_PAGE_ID = listOf(
+            "dooray_wiki_get_page_comments",
+        )
 
         /** post_id를 required로 가져야 하는 도구 목록 */
         private val TOOLS_REQUIRING_POST_ID = listOf(
@@ -108,6 +117,10 @@ class McpServerIntegrationTest {
     @DisplayName("모든 필수 도구가 등록되어야 한다")
     fun `all expected tools should be registered`(): Unit = runBlocking {
         val toolNames = client.listTools().tools.map { it.name }
+        assertTrue(
+            toolNames.toSet() == EXPECTED_TOOLS.toSet(),
+            "등록된 도구 목록이 스냅숏과 다릅니다. expected=$EXPECTED_TOOLS, actual=$toolNames"
+        )
         EXPECTED_TOOLS.forEach { expected ->
             assertContains(toolNames, expected, "도구 '$expected'가 등록되지 않았습니다")
         }
@@ -153,6 +166,17 @@ class McpServerIntegrationTest {
             val tool = toolMap[toolName] ?: error("도구 '$toolName'이 등록되지 않았습니다")
             val required = tool.inputSchema.required ?: emptyList()
             assertContains(required, "post_id", "도구 '$toolName'의 required에 post_id가 없습니다")
+        }
+    }
+
+    @Test
+    @DisplayName("page_id가 필요한 도구는 required에 page_id가 선언되어야 한다")
+    fun `tools requiring page_id should declare it as required`(): Unit = runBlocking {
+        val toolMap = client.listTools().tools.associateBy { it.name }
+        TOOLS_REQUIRING_PAGE_ID.forEach { toolName ->
+            val tool = toolMap[toolName] ?: error("도구 '$toolName'이 등록되지 않았습니다")
+            val required = tool.inputSchema.required ?: emptyList()
+            assertContains(required, "page_id", "도구 '$toolName'의 required에 page_id가 없습니다")
         }
     }
 

--- a/src/test/kotlin/com/bifos/dooray/mcp/tools/McpToolsUnitTest.kt
+++ b/src/test/kotlin/com/bifos/dooray/mcp/tools/McpToolsUnitTest.kt
@@ -592,6 +592,156 @@ class McpToolsUnitTest {
     }
 
     @Test
+    @DisplayName("위키 댓글 목록 조회 도구 - 성공 케이스")
+    fun testGetWikiPageCommentsHandlerSuccess() = runTest {
+        // given
+        val mockDoorayClient = mockk<DoorayClient>()
+
+        val mockComments =
+            listOf(
+                WikiComment(
+                    id = "3950295078642684620",
+                    page = WikiCommentPage(id = "3521165468947041024"),
+                    createdAt = "2024-12-03T17:51:10+09:00",
+                    modifiedAt = "2024-12-03T17:51:10+09:00",
+                    creator =
+                        Creator(
+                            type = "member",
+                            member = Member(organizationMemberId = "3521165460461543659", name = "두레이")
+                        ),
+                    body = WikiCommentBody(mimeType = "text/x-markdown", content = "hello")
+                )
+            )
+        val mockResponse =
+            WikiCommentListResponse(
+                header =
+                    DoorayApiHeader(
+                        isSuccessful = true,
+                        resultCode = 0,
+                        resultMessage = "success"
+                    ),
+                result = mockComments,
+                totalCount = 27
+            )
+
+        coEvery { mockDoorayClient.getWikiPageComments(any(), any(), any(), any()) } returns mockResponse
+
+        val mockRequest = mockk<CallToolRequest>()
+        every { mockRequest.arguments } returns
+                buildJsonObject {
+                    put("project_id", "wiki1")
+                    put("page_id", "page1")
+                    put("page", 0)
+                    put("size", 10)
+                }
+
+        // when
+        val handler = getWikiPageCommentsHandler(mockDoorayClient)
+        val result = handler(mockk<ClientConnection>(), mockRequest)
+
+        // then
+        assertTrue(result.content.isNotEmpty())
+        val content = result.content.first() as TextContent
+        val responseText = content.text
+        assertContains(responseText, "\"success\": true")
+        assertContains(responseText, "\"comments\":")
+        assertContains(responseText, "\"totalCount\": 27")
+        assertContains(responseText, "\"currentPage\": 0")
+        assertContains(responseText, "\"pageSize\": 10")
+        assertContains(responseText, "hello")
+    }
+
+    @Test
+    @DisplayName("위키 댓글 목록 조회 도구 - project_id 누락 에러")
+    fun testGetWikiPageCommentsHandlerMissingProjectId() = runTest {
+        // given
+        val mockDoorayClient = mockk<DoorayClient>()
+
+        val mockRequest = mockk<CallToolRequest>()
+        every { mockRequest.arguments } returns
+                buildJsonObject {
+                    put("page_id", "page1")
+                    // project_id 누락
+                }
+
+        // when
+        val handler = getWikiPageCommentsHandler(mockDoorayClient)
+        val result = handler(mockk<ClientConnection>(), mockRequest)
+
+        // then
+        assertTrue(result.content.isNotEmpty())
+        val content = result.content.first() as TextContent
+        val responseText = content.text
+        assertContains(responseText, "\"isError\": true")
+        assertContains(responseText, "MISSING_PROJECT_ID")
+    }
+
+    @Test
+    @DisplayName("위키 댓글 목록 조회 도구 - page_id 누락 에러")
+    fun testGetWikiPageCommentsHandlerMissingPageId() = runTest {
+        // given
+        val mockDoorayClient = mockk<DoorayClient>()
+
+        val mockRequest = mockk<CallToolRequest>()
+        every { mockRequest.arguments } returns
+                buildJsonObject {
+                    put("project_id", "wiki1")
+                    // page_id 누락
+                }
+
+        // when
+        val handler = getWikiPageCommentsHandler(mockDoorayClient)
+        val result = handler(mockk<ClientConnection>(), mockRequest)
+
+        // then
+        assertTrue(result.content.isNotEmpty())
+        val content = result.content.first() as TextContent
+        val responseText = content.text
+        assertContains(responseText, "\"isError\": true")
+        assertContains(responseText, "MISSING_PAGE_ID")
+    }
+
+    @Test
+    @DisplayName("위키 댓글 목록 조회 도구 - API 에러 케이스")
+    fun testGetWikiPageCommentsHandlerApiError() = runTest {
+        // given
+        val mockDoorayClient = mockk<DoorayClient>()
+
+        val mockResponse =
+            WikiCommentListResponse(
+                header =
+                    DoorayApiHeader(
+                        isSuccessful = false,
+                        resultCode = 404,
+                        resultMessage = "Page not found"
+                    ),
+                result = emptyList(),
+                totalCount = 0
+            )
+
+        coEvery { mockDoorayClient.getWikiPageComments(any(), any(), any(), any()) } returns mockResponse
+
+        val mockRequest = mockk<CallToolRequest>()
+        every { mockRequest.arguments } returns
+                buildJsonObject {
+                    put("project_id", "wiki1")
+                    put("page_id", "invalid_page_id")
+                }
+
+        // when
+        val handler = getWikiPageCommentsHandler(mockDoorayClient)
+        val result = handler(mockk<ClientConnection>(), mockRequest)
+
+        // then
+        assertTrue(result.content.isNotEmpty())
+        val content = result.content.first() as TextContent
+        val responseText = content.text
+        assertContains(responseText, "\"isError\": true")
+        assertContains(responseText, "Page not found")
+        assertContains(responseText, "DOORAY_API_404")
+    }
+
+    @Test
     @DisplayName("업무 댓글 생성 도구 - 성공 케이스")
     fun testCreatePostCommentHandlerSuccess() = runTest {
         // given


### PR DESCRIPTION
dooray_wiki_get_page_comments 툴을 추가하여
GET /wiki/v1/wikis/{wiki-id}/pages/{page-id}/comments 엔드포인트로 위키 페이지의 댓글을 최신순으로 조회한다. page/size 페이징을 지원하며
단위 테스트를 포함한다.